### PR TITLE
Update KeePassXC.download.recipe

### DIFF
--- a/KeePassXC/KeePassXC.download.recipe
+++ b/KeePassXC/KeePassXC.download.recipe
@@ -11,7 +11,7 @@
 		<key>NAME</key>
 		<string>KeePassXC</string>
 		<key>ASSET_REGEX</key>
-		<string>KeePassXC-.*(?&lt;!Sierra)\.dmg</string>
+		<string>KeePassXC-.*-x86_64\.dmg</string>
 	</dict>
 	<key>MinimumVersion</key>
 	<string>0.6.0</string>


### PR DESCRIPTION
The `ASSET_REGEX` value needs to be changed for version 2.6.4 and up. KeePassXC now provides separate `x86_64` and `arm64` versions, and the current `ASSET_REGEX` value grabs the `arm64` version by chance. This will only work on the minority of current devices, so I would suggest to specify the `x86_64` version as in this PR by default, while continuing to allow people to override the `ASSET_REGEX` key to grab the `arm64` version should they wish to do so.

I have overridden the `ASSET_REGEX` key to obtain the `x86_64` dmg, but it would be good to not have to manually maintain the `ASSET_REGEX` key in my override  in future, so I would appreciate this PR being granted to avoid that scenario :)